### PR TITLE
RIS-2832 Removed regex removing comments from query

### DIFF
--- a/src/php/application/sql/QuerySplitter.php
+++ b/src/php/application/sql/QuerySplitter.php
@@ -22,7 +22,6 @@ class QuerySplitter
      */
     private function removeCommentsAndSpaces($sql)
     {
-        $sql = preg_replace('@--.*?\n@mis', '', $sql);
         $sql = preg_replace('@\/\*.*?\*\/@mis', '', $sql);
         /* Trim spaces on blank lines */
         $sql = preg_replace('@^\s*\n@mis', "\n", $sql);


### PR DESCRIPTION
Removed regex removing comments from query as we want to keep comments in:
- stored procedures
- values containing double dashes `--`  (ex. cmd line parameters)

**IMPORTANT:**
Do not use question mark (**?**) nor PDO parameter syntax (**:word**) inside comments as this will cause PDO to fail.
